### PR TITLE
Add `--var-cmd`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,40 @@
 use rustop::opts;
-use tree_sitter::Parser;
+use tree_sitter::{Language, Node, Parser, Range};
+
+fn run_query(
+    query_str: &str,
+    match_name: &str,
+    lang: &Language,
+    node: &Node,
+    code: &[u8],
+) -> Vec<(std::ops::Range<usize>, Range)> {
+    let query = tree_sitter::Query::new(*lang, query_str).unwrap();
+
+    let mut query_cursor = tree_sitter::QueryCursor::new();
+    let all_matches = query_cursor.matches(&query, *node, code);
+
+    let command_name_index = query.capture_index_for_name(match_name).unwrap();
+    let mut commands = Vec::new();
+    for each_match in all_matches {
+        for capture in each_match
+            .captures
+            .iter()
+            .filter(|c| c.index == command_name_index)
+        {
+            let byte_range = capture.node.byte_range();
+            let range = capture.node.range();
+            commands.push((byte_range, range));
+        }
+    }
+    commands
+}
 
 fn main() {
     let (args, _) = opts! {
         synopsis r#"This program extracts all command in a given Bash script.
 The output format is {command} {line} {column}.
 "#;
+        opt var_cmd:bool=false, desc:"Extract variables storing command names";
         param file:String, desc:"The file to extract commands from.";
     }
     .parse_or_exit();
@@ -17,6 +46,7 @@ The output format is {command} {line} {column}.
             std::process::exit(1);
         }
     };
+    let code_bytes = code.as_bytes();
 
     let mut parser = Parser::new();
     let bash_language = tree_sitter_bash::language();
@@ -30,33 +60,46 @@ The output format is {command} {line} {column}.
             std::process::exit(1);
         }
     };
-    let query = tree_sitter::Query::new(
-        bash_language,
+
+    let mut command_ranges = run_query(
         r#"
-(command
-    name:
-        (command_name
-            (word) @command_name))
-    "#,
-    )
-    .unwrap();
+    (command
+        name:
+            (command_name
+                (word) @command_name))
+        "#,
+        "command_name",
+        &bash_language,
+        &parsed.root_node(),
+        &code_bytes,
+    );
+    if args.var_cmd {
+        command_ranges.append(&mut run_query(
+            r#"
+        (command
+            name: (command_name
+              (simple_expansion
+                (variable_name)) @variable))
+                "#,
+            "variable",
+            &bash_language,
+            &parsed.root_node(),
+            &code_bytes,
+        ));
+    }
 
-    let mut query_cursor = tree_sitter::QueryCursor::new();
-    let all_matches = query_cursor.matches(&query, parsed.root_node(), code.as_bytes());
-
-    let command_name_index = query.capture_index_for_name("command_name").unwrap();
-    for each_match in all_matches {
-        for capture in each_match
-            .captures
-            .iter()
-            .filter(|c| c.index == command_name_index)
-        {
-            let byte_range = capture.node.byte_range();
-            let range = capture.node.range();
-            let text = &code[byte_range.start..byte_range.end];
-            let line = range.start_point.row + 1;
-            let col = range.start_point.column + 1;
-            println!("{} {} {}", text, line, col);
+    command_ranges.sort_by(|(byte_range1, _), (byte_range2, _)| {
+        if byte_range1.start != byte_range2.start {
+            byte_range1.start.cmp(&byte_range2.start)
+        } else {
+            byte_range1.end.cmp(&byte_range2.end)
         }
+    });
+
+    for (byte_range, range) in command_ranges {
+        let text = &code[byte_range.start..byte_range.end];
+        let line = range.start_point.row + 1;
+        let col = range.start_point.column + 1;
+        println!("{} {} {}", text, line, col);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,7 +71,7 @@ The output format is {command} {line} {column}.
         "command_name",
         &bash_language,
         &parsed.root_node(),
-        &code_bytes,
+        code_bytes,
     );
     if args.var_cmd {
         command_ranges.append(&mut run_query(
@@ -84,7 +84,7 @@ The output format is {command} {line} {column}.
             "variable",
             &bash_language,
             &parsed.root_node(),
-            &code_bytes,
+            code_bytes,
         ));
     }
 

--- a/test.sh
+++ b/test.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 
-diff <(cargo run -- test/test01.sh) test/expected01.txt
-if cargo run -- test/a_file_does_not_exist_908yafa98.txt; then
+cargo build
+CMD='target/debug/extract-bash-command'
+
+diff <($CMD test/test01.sh) test/expected01.txt
+
+# a test for no existing file
+if $CMD test/a_file_does_not_exist_908yafa98.txt 2> /dev/null; then
     exit 1
 fi
+
+# test --var-cmd
+diff <($CMD --var-cmd test/test02_var_cmd.sh) test/expected02_var_cmd.txt

--- a/test/expected02_var_cmd.txt
+++ b/test/expected02_var_cmd.txt
@@ -1,0 +1,7 @@
+$ECHO 4 1
+echo 6 1
+$ECHO 6 9
+echo 8 20
+cat 10 5
+echo 10 11
+$SED 10 24

--- a/test/test02_var_cmd.sh
+++ b/test/test02_var_cmd.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+ECHO=echo
+SED=sed
+$ECHO hello
+export TEST_VAR=HELLO
+echo "$($ECHO $TEST_VAR)"
+if [ "hello" = "world" ]; then
+    TEST_VAR=WORLD echo $TEST_VAR # echo hello
+else
+    cat <(echo hello | $SED s/hello/world/g)
+fi


### PR DESCRIPTION
This pull request a new command line option `--var-cmd`.
When this option is enabled, this command extracts variable names storing command name.
For example, the output is `$ECHO 2 1` if `--var-cmd` is enabled and the input file is the following.

```bash
ECHO=echo
$ECHO hello
```